### PR TITLE
Do not show dbus error when spotify is not running

### DIFF
--- a/spotify.py
+++ b/spotify.py
@@ -57,9 +57,9 @@ class Spotify(base.ThreadPoolText):
     def _is_proc_running(self, proc_name: str) -> bool:
         # create regex pattern to search for to avoid similar named processes
         pattern = f"{proc_name}$"
-
         # pgrep will return a string of pids for matching processes
-        proc_out = run(["pgrep", "-fli", pattern], capture_output=True).stdout.decode(
+        cmd = ["pgrep", "-fli", pattern]
+        proc_out = run(cmd, capture_output=True).stdout.decode(
             "utf-8"
         )
 
@@ -108,45 +108,55 @@ class Spotify(base.ThreadPoolText):
     def poll(self) -> str: # type: ignore
         """Poll content for the text box"""
         vars = {
-            "icon": self.play_icon if self.playing else self.pause_icon,
+            "icon": self.pause_icon if self.playing else self.play_icon,
             "artist": self.artist,
             "track": self.song_title,
             "album": self.album,
         }
 
-        return self.format.format(**vars) # type: ignore 
+        return self.format.format(**vars) # type: ignore
 
     def toggle_music(self) -> None:
-        run(
-            "dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.PlayPause",
-            shell=True,
-        )
+        cmd = """
+        dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify \
+        /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.PlayPause
+        """
+        run(cmd, shell=True)
+
 
     def get_proc_output(self, proc: CompletedProcess) -> str:
-        if proc.stderr.decode("utf-8") != "":
-            return (
-                ""
-                if "org.mpris.MediaPlayer2.spotify" in proc.stderr.decode("utf-8")
-                else proc.stderr.decode("utf-8")
-            )
+        stdout = proc.stdout.decode("utf-8")
+        no_spotify = "Error" in stdout
+        return (
+            ""
+            if no_spotify
+            else stdout.rstrip()
+        )
 
-        return proc.stdout.decode("utf-8").rstrip()
 
     @property
     def _meta(self) -> str:
-        proc = run(
-            "dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'",
-            shell=True,
-            capture_output=True,
-        )
+        cmd = """dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify \
+            /org/mpris/MediaPlayer2 \
+            org.freedesktop.DBus.Properties.Get \
+            string:'org.mpris.MediaPlayer2.Player' \
+            string:'Metadata'
+        """
+        proc = run( cmd, shell=True, capture_output=True)
 
         output: str = proc.stdout.decode("utf-8").replace("'", "ʼ").rstrip()
         return "" if ("org.mpris.MediaPlayer2.spotify" in output) else output
 
     @property
     def artist(self) -> str:
-        proc: CompletedProcess = run(
-            "dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata' | grep -m1 'xesam:artist' -b2 | tail -n 1 | grep -o '\".*\"' | sed 's/\"//g' | sed -e 's/&/and/g'",
+        cmd ="""
+        dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify \
+        /org/mpris/MediaPlayer2 \
+        org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' \
+        string:'Metadata' | grep -m1 'xesam:artist' -b2 | tail -n 1 | grep -o '\".*\"' | \
+        sed 's/\"//g' | sed -e 's/&/and/g'
+        """
+        proc: CompletedProcess = run(cmd,
             shell=True,
             capture_output=True,
         )
@@ -155,18 +165,24 @@ class Spotify(base.ThreadPoolText):
 
     @property
     def song_title(self) -> str:
-        proc: CompletedProcess = run(
-            f"echo '{self._meta}' | grep -m1 'xesam:title' -b1 | tail -n1 | grep -o '\".*\"' | sed 's/\"//g' | sed -e 's/&/and/g'",
+        cmd = f"""
+        echo '{self._meta}' | grep -m1 'xesam:title' -b1 | tail -n1 | grep -o '\".*\"' | \
+        sed 's/\"//g' | sed -e 's/&/and/g'
+        """
+        proc: CompletedProcess = run(cmd,
             shell=True,
-            capture_output=True,
+            capture_output=True
         )
 
         return self.get_proc_output(proc)
 
     @property
     def album(self) -> str:
-        proc = run(
-            f"echo '{self._meta}' | grep -m1 'xesam:album' -b1 | tail -n1 | grep -o '\".*\"' | sed 's/\"//g' | sed -e 's/&/and/g'",
+        cmd =  f"""
+        echo '{self._meta}' | grep -m1 'xesam:album' -b1 | tail -n1 | grep -o '\".*\"' | \
+        sed 's/\"//g' | sed -e 's/&/and/g'
+        """
+        proc = run(cmd,
             shell=True,
             capture_output=True,
         )
@@ -175,8 +191,12 @@ class Spotify(base.ThreadPoolText):
 
     @property
     def playing(self) -> bool:
-        play = run(
-            "dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'PlaybackStatus' | grep -o Playing",
+        cmd = """
+        dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify \
+        /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get \
+        string:'org.mpris.MediaPlayer2.Player' string:'PlaybackStatus' | grep -o Playing
+        """
+        play = run(cmd,
             shell=True,
             capture_output=True,
         ).stdout.decode("utf-8")


### PR DESCRIPTION
Previously I was checking STDERR to see what to display to the user however it seems that errors are not just print to STDOUT instead.  Fix -> just read STDOUT instead and errors go away.