### PR TITLE
spotify.py: fixed mismatched icon for play/pause

### DIFF
--- a/spotify.py
+++ b/spotify.py
@@ -108,7 +108,7 @@ class Spotify(base.ThreadPoolText):
     def poll(self) -> str: # type: ignore
         """Poll content for the text box"""
         vars = {
-            "icon": self.pause_icon if self.playing else self.play_icon,
+            "icon": self.play_icon if self.playing else self.pause_icon,
             "artist": self.artist,
             "track": self.song_title,
             "album": self.album,


### PR DESCRIPTION
Original spotify.py file has pause showing when Spotify is playing and vise versa.

Changed the poll definition to have pause when Spotify is paused and play when it is playing.